### PR TITLE
fix group avatars when no image exists

### DIFF
--- a/src/components/Group/View/index.jsx
+++ b/src/components/Group/View/index.jsx
@@ -19,6 +19,11 @@ const ViewGroup = ({ currentUser, groupData, threads }) => {
   const [adminTab, setAdminTab] = React.useState(false);
   const [isAdmin, setAdmin] = React.useState(false);
 
+  let iconUrlExists = true;
+  if (groupData.iconUrl == undefined) {
+    iconUrlExists = false;
+  }
+
   const groupAction = async () => {
     if (joined) {
       await unfollowGroup(null, groupData._id);
@@ -68,11 +73,14 @@ const ViewGroup = ({ currentUser, groupData, threads }) => {
       {groupData && (
         <>
           <div className={styles.GroupHeader}>
-            <img
-              className={styles.GroupAvatar}
-              src={groupData.iconUrl}
-              alt="Group Avatar"
-            />
+            {iconUrlExists && (
+              <img
+                className={styles.GroupAvatar}
+                src={groupData.iconUrl}
+                alt="No Image"
+              />
+            )}
+            {!iconUrlExists && <div className={styles.GroupAvatar}></div>}
             {isAdmin ? (
               <Icon
                 className={styles.AdminIcon}


### PR DESCRIPTION
Changed the view of groups so that if no image is selected for the group. It now shows up as nothing when you click on the group